### PR TITLE
Check clipboard copy&paste

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,12 +2,14 @@
 SET_DIR=~/utility/scripts/vimdic
 IS_FRST_SET=$(grep -c vimdic ~/.bashrc)
 IS_LOCALE_SET=$(locale -a | grep -c ko_KR.utf8)
+IS_CLIPBOARD_SET=$(vim --version | grep -c [+]clipboard)
+
 chmod 775 $SET_DIR/vimdic.sh
 if [ $IS_FRST_SET == 0 ]; then
 	echo "Setting vimdic.."
 
 	# Set locale to ko_KR.UTF-8
-	if [ $IS_LOCALE_SET != 0 ]; then
+	if [ $IS_LOCALE_SET == 0 ]; then
 		sudo locale-gen ko_KR.UTF-8
 		sudo dpkg-reconfigure locales
 		if [ $(locale -a | grep -c ko_KR.utf8) == 0 ]; then
@@ -17,6 +19,17 @@ if [ $IS_FRST_SET == 0 ]; then
 		fi
 	else
 		echo "Already set locale"
+	fi
+
+	if [ $IS_CLIPBOARD_SET == 0 ]; then
+		sudo apt-get install vim-gnome
+		if [ $IS_CLIPBOARD_SET == 0]; then
+			echo "Fail to setup vim clipboard"
+		else
+			echo "Success to setup vim clipboard"
+		fi
+	else
+		echo "Already set vim clipboard"
 	fi
 
 	sudo apt-get install w3m


### PR DESCRIPTION
To use "+y which can copy to clipboard, +clipboard show up when typing\
 vim --version. If there is -clipboard instead +clipboard, It needs to set \
apt-get install vim-gnome
