### PR TITLE
In -rm mode, Removing tt keymap from vimrc file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,14 @@ VD=vimdic.sh
 
 chmod 775 $VD
 if [ "$1" == "-rm" ]; then
-	sudo rm $SET_DIR/$VD
+	if [ -f $SET_DIR/$VD ]; then
+		sudo rm $SET_DIR/$VD
+		sed -i "/nmap tt :!vimdic.sh<Space><cword><CR>/d" ~/.vimrc
+		sed -i "/xmap tt \"+y<ESC>:!vimdic.sh<Space><C-R><C-O>/d" ~/.vimrc
+		echo "Removing vimdic is done.."
+	else
+		echo "Removing vimdic is already done.."
+	fi
 else
 	if [ -f $SET_DIR/$VD ]; then
 		echo "Vimdic already set"


### PR DESCRIPTION
'tt' keymap was added by setup.sh.\
And It also removed by executing the setup.sh with -rm mode
